### PR TITLE
fixing network issue that causes crash when player status is stop

### DIFF
--- a/ios/ReactAudio/ReactAudio.m
+++ b/ios/ReactAudio/ReactAudio.m
@@ -137,22 +137,21 @@ RCT_EXPORT_METHOD(seekTo:(int) nSecond) {
 -(void) pauseOrStop:(NSString *)value {
     [self.player pause];
     
-    songInfo = @{
-                 MPMediaItemPropertyTitle: rapName,
-                 MPMediaItemPropertyArtist: songTitle,
-                 MPNowPlayingInfoPropertyPlaybackRate: [NSNumber numberWithFloat: 0.0],
-                 MPMediaItemPropertyPlaybackDuration: [NSNumber numberWithFloat:duration],
-                 MPNowPlayingInfoPropertyElapsedPlaybackTime: [NSNumber numberWithDouble:self.currentPlaybackTime],
-                 MPMediaItemPropertyArtwork: albumArt ? albumArt : defaultAlbumArt
-                 };
-    center.nowPlayingInfo = songInfo;
-    
     if ([value isEqualToString:@"STOP"]) {
         CMTime newTime = CMTimeMakeWithSeconds(0, 1);
         [self.player seekToTime:newTime];
         albumArt = nil;
     } else {
         [self deactivate];
+        songInfo = @{
+                     MPMediaItemPropertyTitle: rapName,
+                     MPMediaItemPropertyArtist: songTitle,
+                     MPNowPlayingInfoPropertyPlaybackRate: [NSNumber numberWithFloat: 0.0],
+                     MPMediaItemPropertyPlaybackDuration: [NSNumber numberWithFloat:duration],
+                     MPNowPlayingInfoPropertyElapsedPlaybackTime: [NSNumber numberWithDouble:self.currentPlaybackTime],
+                     MPMediaItemPropertyArtwork: albumArt ? albumArt : defaultAlbumArt
+                     };
+        center.nowPlayingInfo = songInfo;
     }
     
     if (playbackTimeObserver) {


### PR DESCRIPTION
app was crashing when trying to play track for the first time under no network
and it is because when there is no network, player status changes to stop first which triggers to update lock screen data with no artwork info.

-> lock screen update is not needed when player status is stop, so applying it only when player status is pause. 