### PR TITLE
[iOS] removing avplayerItem observer on stop

### DIFF
--- a/ios/ReactAudio/ReactAudio.m
+++ b/ios/ReactAudio/ReactAudio.m
@@ -129,6 +129,7 @@ RCT_EXPORT_METHOD(seekTo:(int) nSecond) {
     if ([value isEqualToString:@"STOP"]) {
         CMTime newTime = CMTimeMakeWithSeconds(0, 1);
         [self.player seekToTime:newTime];
+        [self.playerItem removeObserver:self forKeyPath:@"status"];
         albumArt = nil;
     } else {
         [self deactivate];


### PR DESCRIPTION
### Issue resolved
app crash on pressing next/prev track because of avplayerItem observer

### Fix
removing avplayerItem observer on stop
